### PR TITLE
refactor: make a separate analyzer

### DIFF
--- a/src/MonkeyLang.jl
+++ b/src/MonkeyLang.jl
@@ -35,6 +35,9 @@ include("ast_modify.jl")
 # Symbol and Symbol Table
 include("symbol_table.jl")
 
+# Analyzer
+include("analyzer.jl")
+
 # Compiler
 include("compiler.jl")
 

--- a/src/analyzer.jl
+++ b/src/analyzer.jl
@@ -1,0 +1,193 @@
+function analyze(code::String; input::IO = stdin, output::IO = stdout)
+    raw_program = parse(code; input, output)
+    if !isnothing(raw_program)
+        macro_env = Environment(; input, output)
+        program = define_macros!(macro_env, raw_program)
+        expanded = expand_macros(program, macro_env)
+        return analyze(expanded)
+    end
+end
+
+function analyze(program::Program)
+    symbol_table = SymbolTable()
+    for (i, (name, _)) in enumerate(BUILTINS)
+        define_builtin!(symbol_table, name, i - 1)
+    end
+
+    for statement in program.statements
+        result = analyze(statement, symbol_table)
+        if isa(result, ErrorObj)
+            return result
+        end
+    end
+end
+
+function analyze(bs::BlockStatement, symbol_table::SymbolTable)
+    for statement in bs.statements
+        result = analyze(statement, symbol_table)
+        if isa(result, ErrorObj)
+            return result
+        end
+    end
+end
+
+analyze(es::ExpressionStatement, symbol_table::SymbolTable) =
+    analyze(es.expression, symbol_table)
+
+function analyze(ls::LetStatement, symbol_table::SymbolTable)
+    sym, _ = resolve(symbol_table, ls.name.value)
+
+    if ls.reassign
+        if isnothing(sym)
+            return ErrorObj("identifier not found: $(ls.name.value)")
+        end
+
+        if sym.scope == FunctionScope ||
+           (sym.scope == OuterScope && sym.ptr.scope == FunctionScope)
+            return ErrorObj(
+                "cannot reassign the current function being defined: $(ls.name.value)",
+            )
+        end
+    else
+        if !isnothing(sym)
+            return ErrorObj("$(ls.name.value) is already defined")
+        end
+
+        define!(symbol_table, ls.name.value)
+    end
+
+    return analyze(ls.value, symbol_table)
+end
+
+function analyze(ws::WhileStatement, symbol_table::SymbolTable)
+    result = analyze(ws.condition, symbol_table)
+    if isa(result, ErrorObj)
+        return result
+    end
+
+    inner = SymbolTable(symbol_table; within_loop = true)
+    return analyze(ws.body, inner)
+end
+
+analyze(rs::ReturnStatement, symbol_table::SymbolTable) =
+    analyze(rs.return_value, symbol_table)
+
+function analyze(::BreakStatement, symbol_table::SymbolTable)
+    if !within_loop(symbol_table)
+        return ErrorObj("syntax error: break outside loop")
+    end
+end
+
+function analyze(::ContinueStatement, symbol_table::SymbolTable)
+    if !within_loop(symbol_table)
+        return ErrorObj("syntax error: continue outside loop")
+    end
+end
+
+function analyze(ident::Identifier, symbol_table::SymbolTable)
+    sym, _ = resolve(symbol_table, ident.value)
+    if isnothing(sym)
+        return ErrorObj("identifier not found: $(ident.value)")
+    end
+end
+
+function analyze(al::ArrayLiteral, symbol_table::SymbolTable)
+    for element in al.elements
+        result = analyze(element, symbol_table)
+        if isa(result, ErrorObj)
+            return result
+        end
+    end
+end
+
+function analyze(hl::HashLiteral, symbol_table::SymbolTable)
+    for (key, value) in hl.pairs
+        result = analyze(key, symbol_table)
+        if isa(result, ErrorObj)
+            return result
+        end
+
+        result = analyze(value, symbol_table)
+        if isa(result, ErrorObj)
+            return result
+        end
+    end
+end
+
+function analyze(fl::FunctionLiteral, symbol_table::SymbolTable)
+    inner = SymbolTable(symbol_table)
+
+    if !isempty(fl.name)
+        define_function!(inner, fl.name)
+    end
+
+    for param in fl.parameters
+        define!(inner, param.value)
+    end
+
+    return analyze(fl.body, inner)
+end
+
+function analyze(ie::IfExpression, symbol_table::SymbolTable)
+    result = analyze(ie.condition, symbol_table)
+    if isa(result, ErrorObj)
+        return result
+    end
+
+    result = analyze(ie.consequence, symbol_table)
+    if isa(result, ErrorObj)
+        return result
+    end
+
+    if !isnothing(ie.alternative)
+        return analyze(ie.alternative, symbol_table)
+    end
+end
+
+analyze(pe::PrefixExpression, symbol_table::SymbolTable) = analyze(pe.right, symbol_table)
+
+function analyze(ie::InfixExpression, symbol_table::SymbolTable)
+    result = analyze(ie.left, symbol_table)
+    if isa(result, ErrorObj)
+        return result
+    end
+
+    return analyze(ie.right, symbol_table)
+end
+
+function analyze(ie::IndexExpression, symbol_table::SymbolTable)
+    result = analyze(ie.left, symbol_table)
+    if isa(result, ErrorObj)
+        return result
+    end
+
+    return analyze(ie.index, symbol_table)
+end
+
+function analyze(ce::CallExpression, symbol_table::SymbolTable)
+    if (token_literal(ce.fn) == "quote")
+        return nothing
+    end
+
+    result = analyze(ce.fn, symbol_table)
+    if isa(result, ErrorObj)
+        return result
+    end
+
+    for arg in ce.arguments
+        result = analyze(arg, symbol_table)
+        if isa(result, ErrorObj)
+            return result
+        end
+    end
+end
+
+# The following functions do nothing in the current version.
+
+analyze(il::IntegerLiteral, symbol_table::SymbolTable) = nothing
+
+analyze(sl::StringLiteral, symbol_table::SymbolTable) = nothing
+
+analyze(bl::BooleanLiteral, symbol_table::SymbolTable) = nothing
+
+analyze(::NullLiteral, ::SymbolTable) = nothing

--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -152,6 +152,4 @@ get_builtin_by_name(name::String) = begin
             return builtin
         end
     end
-
-    return nothing
 end

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -60,15 +60,16 @@ function start_repl(; input::IO = stdin, output::IO = stdout, use_vm::Bool = fal
 
             try
                 expanded = expand_macros(program, macro_env)
+                syntax_check_result = analyze(expanded)
+                if isa(syntax_check_result, ErrorObj)
+                    println(output, syntax_check_result)
+                    continue
+                end
+
                 if use_vm
+                    # There should be no compilation errors.
                     c = Compiler(symbol_table, constants)
-                    try
-                        compile!(c, expanded)
-                    catch e
-                        msg = hasproperty(e, :msg) ? e.msg : "unknown error"
-                        println(output, ErrorObj("compilation error: $msg"))
-                        continue
-                    end
+                    compile!(c, expanded)
 
                     vm = VM(bytecode(c), globals; input = input, output = output)
                     result = run!(vm)

--- a/src/symbol_table.jl
+++ b/src/symbol_table.jl
@@ -24,8 +24,12 @@ mutable struct SymbolTable
         new(Dict(), 0, outer, within_loop, [])
 end
 
+is_global(s::SymbolTable) = isnothing(s.outer)
+
+within_loop(s::SymbolTable) = s.within_loop
+
 define!(s::SymbolTable, name::String) = begin
-    scope = isnothing(s.outer) ? GlobalScope : LocalScope
+    scope = is_global(s) ? GlobalScope : LocalScope
     sym = MonkeySymbol(name, scope, s.definition_count, nothing)
     s.store[name] = sym
     s.definition_count += 1

--- a/src/transpilers/julia/julia_transpiler.jl
+++ b/src/transpilers/julia/julia_transpiler.jl
@@ -226,6 +226,13 @@ transpile(code::String; input::IO = stdin, output::IO = stdout) = begin
         macro_env = MonkeyLang.Environment(; input, output)
         program = MonkeyLang.define_macros!(macro_env, raw_program)
         expanded = MonkeyLang.expand_macros(program, macro_env)
+
+        syntax_check_result = MonkeyLang.analyze(expanded)
+        if isa(syntax_check_result, MonkeyLang.ErrorObj)
+            println(output, syntax_check_result)
+            return nothing
+        end
+
         return transpile(expanded; input, output)
     end
 end

--- a/src/vm.jl
+++ b/src/vm.jl
@@ -75,6 +75,13 @@ run(code::String; input = stdin, output = stdout) = begin
         macro_env = Environment(; input, output)
         program = define_macros!(macro_env, raw_program)
         expanded = expand_macros(program, macro_env)
+
+        syntax_check_result = analyze(expanded)
+        if isa(syntax_check_result, ErrorObj)
+            println(output, syntax_check_result)
+            return syntax_check_result
+        end
+
         c = Compiler()
         compile!(c, expanded)
         vm = VM(bytecode(c), Object[]; input, output)

--- a/test/analyzer_test.jl
+++ b/test/analyzer_test.jl
@@ -1,0 +1,33 @@
+@testset "Test analyzer" begin
+    @testset "Semantic analysis" begin
+        for (code, expected) in [
+            ("foobar", "identifier not found: foobar"),
+            ("x = 2;", "identifier not found: x"),
+            ("let a = 2; let a = 4;", "a is already defined"),
+            ("break;", "syntax error: break outside loop"),
+            ("continue;", "syntax error: continue outside loop"),
+            ("fn () { break; } ", "syntax error: break outside loop"),
+            ("fn () { continue; } ", "syntax error: continue outside loop"),
+            ("while (x == 2) {}", "identifier not found: x"),
+            ("while (true) { x = 2; }", "identifier not found: x"),
+            ("if (x == 2) {}", "identifier not found: x"),
+            ("if (true) { x }", "identifier not found: x"),
+            ("if (true) { 2 } else { x }", "identifier not found: x"),
+            ("-x", "identifier not found: x"),
+            ("x + 2", "identifier not found: x"),
+            ("x(3)", "identifier not found: x"),
+            ("x[3]", "identifier not found: x"),
+            ("[1, 2][x]", "identifier not found: x"),
+            ("len(x)", "identifier not found: x"),
+            ("[x]", "identifier not found: x"),
+            ("{x: 2}", "identifier not found: x"),
+            ("{2: x}", "identifier not found: x"),
+            (
+                "let f = fn(x) { if (x > 0) { f(x - 1); f = 2; } }",
+                "cannot reassign the current function being defined: f",
+            ),
+        ]
+            test_object(m.analyze(code), expected)
+        end
+    end
+end

--- a/test/backend_test.jl
+++ b/test/backend_test.jl
@@ -387,58 +387,45 @@ function test_backend(run::Function, name::String; check_object::Bool = true)
         end
 
         @testset "Closure" begin
-            for (code, expected) in [
-                (
-                    """
-                   let newAdder = fn(x) { 
-                     fn(y) { x + y };
-                   }
+            for (code, expected) in [(
+                """
+               let newAdder = fn(x) { 
+                 fn(y) { x + y };
+               }
 
-                   let addTwo = newAdder(2);
-                   addTwo(2);
-                   """,
-                    4,
-                ),
-            ]
+               let addTwo = newAdder(2);
+               addTwo(2);
+               """,
+                4,
+            ), (
+                """
+                let a = 2;
+                let ans = [];
 
-                check(code, expected)
-            end
-
-            for (code, expected) in [
-                (
-                    """
-                    let a = 2;
-                    let ans = [];
-
-                    let g = fn() {
-                        let b = 2;
-                        let f = fn() {
-                            b = b - 1;
-                            return b;
-                        }
-                        return f;
+                let g = fn() {
+                    let b = 2;
+                    let f = fn() {
+                        b = b - 1;
+                        return b;
                     }
+                    return f;
+                }
 
-                    let f = g();
+                let f = g();
 
-                    ans = push(ans, f());
-                    ans = push(ans, f());
+                ans = push(ans, f());
+                ans = push(ans, f());
 
-                    let ff = g();
+                let ff = g();
 
-                    ans = push(ans, ff());
-                    ans = push(ans, ff());
+                ans = push(ans, ff());
+                ans = push(ans, ff());
 
-                    ans;
-                    """,
-                    [1, 0, 1, 0],
-                ),
-            ]
-                if name == "evaluator"
-                    @test_broken check(code, expected)
-                else
-                    check(code, expected)
-                end
+                ans;
+                """,
+                [1, 0, 1, 0],
+            )]
+                check(code, expected)
             end
         end
 
@@ -680,14 +667,16 @@ function test_backend(run::Function, name::String; check_object::Bool = true)
                 end
             end
 
-            if name == "evaluator"
-                @testset "semantic analysis" begin
-                    for (code, expected) in [
-                        ("foobar", "identifier not found: foobar"),
-                        ("x = 2;", "identifier not found: x"),
-                        ("let a = 2; let a = 4;", "a is already defined"),
-                    ]
+            @testset "Semantic analysis" begin
+                for (code, expected) in [
+                    ("foobar", "identifier not found: foobar"),
+                    ("x = 2;", "identifier not found: x"),
+                    ("let a = 2; let a = 4;", "a is already defined"),
+                ]
+                    if check_object
                         check(code, expected, "ERROR: $expected\n")
+                    else
+                        check(code, nothing, "ERROR: $expected\n")
                     end
                 end
             end

--- a/test/compiler_test.jl
+++ b/test/compiler_test.jl
@@ -894,35 +894,6 @@
     end
 
     @testset "Error handling" begin
-        for (input, error_message) in [
-            ("break;", "syntax error: break outside loop"),
-            ("let f = fn() { break; }", "syntax error: break outside loop"),
-            ("continue;", "syntax error: continue outside loop"),
-            ("let f = fn() { continue; }", "syntax error: continue outside loop"),
-            ("fn (x) { let x = 3; }", "x is already defined"),
-            ("a", "identifier not found: a"),
-            ("a = 2", "identifier not found: a"),
-            ("let a = 2; let a = 3;", "a is already defined"),
-            (
-                """
-                let f = fn(x) {
-                    while (false) {
-                        f = 2;
-                    }
-
-                    return g;
-                }
-                """,
-                "cannot reassign the current function being defined",
-            ),
-        ]
-            @test_throws ErrorException(error_message) begin
-                program = m.parse(input)
-                c = m.Compiler()
-                m.compile!(c, program)
-            end
-        end
-
         @test_throws ErrorException("unknown operator: &") begin
             c = m.Compiler()
             m.compile!(

--- a/test/repl_test.jl
+++ b/test/repl_test.jl
@@ -43,13 +43,10 @@ using .Threads
     @testset "Use Bytecode VM" begin
         for (raw_input, expected) in [
             (b"1\n2\n", ["1", "2"]),
-            (b"a\n", ["ERROR: compilation error: identifier not found: a"]),
+            (b"a\n", ["ERROR: identifier not found: a"]),
             (
                 b"let b = 1 / 0;\nb;\n",
-                [
-                    "ERROR: divide error: division by zero",
-                    "ERROR: compilation error: identifier not found: b",
-                ],
+                ["ERROR: divide error: division by zero", "ERROR: identifier not found: b"],
             ),
             (
                 b"1 ++ 2\n",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ const m = MonkeyLang
 
     include("code_test.jl")
     include("symbol_table_test.jl")
+    include("analyzer_test.jl")
     include("compiler_test.jl")
 
     include("backend_test.jl")


### PR DESCRIPTION
- Implement a separate syntax analyzer based on the compiler (#16)
  - The original validations in the evaluator and compiler have been removed since they are no longer needed
- Re-enable variable name shadowing (#23)
